### PR TITLE
Add support for creating recurring WFH arrangements

### DIFF
--- a/backend/src/arrangements/crud.py
+++ b/backend/src/arrangements/crud.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from pydantic import ValidationError
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
@@ -5,15 +7,49 @@ from sqlalchemy.orm import Session
 from . import models, schemas
 
 
-def create_wfh_request(db: Session, arrangement_data: schemas.ArrangementCreate):
+def create_bulk_wfh_request(
+    db: Session, arrangements_data: List[schemas.ArrangementCreate]
+):
     try:
-        arrangement = models.ArrangementLog(
-            **arrangement_data.model_dump(by_alias=True)
-        )
-        db.add(arrangement)
+        batch_id = None
+
+        if len(arrangements_data) > 1:
+            batch = models.ArrangementBatch(
+                update_datetime=arrangements_data[0].update_datetime,
+                requester_staff_id=arrangements_data[0].requester_staff_id,
+                start_date=arrangements_data[0].wfh_date,
+                end_date=arrangements_data[0].recurring_end_date,
+                recurring_frequency_number=arrangements_data[
+                    0
+                ].recurring_frequency_number,
+                recurring_frequency_unit=arrangements_data[0].recurring_frequency_unit,
+                recurring_occurrences=arrangements_data[0].recurring_occurrences,
+                wfh_type=arrangements_data[0].wfh_type,
+                reason_description=arrangements_data[0].reason_description,
+            )
+            db.add(batch)
+            db.commit()
+            db.refresh(batch)
+
+            batch_id = batch.batch_id
+
+        arrangements = []
+        for arrangement_data in arrangements_data:
+            arrangement_dict = arrangement_data.model_dump(by_alias=True)
+            # Remove invalid fields
+            valid_fields = {
+                key: value
+                for key, value in arrangement_dict.items()
+                if key in models.ArrangementLog.__table__.columns
+            }
+            valid_fields["batch_id"] = batch_id
+            arrangement = models.ArrangementLog(**valid_fields)
+            arrangements.append(arrangement)
+        db.add_all(arrangements)
         db.commit()
-        db.refresh(arrangement)
-        return arrangement
+        for arrangement in arrangements:
+            db.refresh(arrangement)
+        return arrangements
     except SQLAlchemyError as e:
         db.rollback()
         raise e

--- a/backend/src/arrangements/models.py
+++ b/backend/src/arrangements/models.py
@@ -17,7 +17,7 @@ class ArrangementLog(Base):
         doc="Date and time of the log entry",
     )
     requester_staff_id = Column(
-        Integer,
+        String(length=10),
         ForeignKey("employees.staff_id"),
         nullable=False,
         doc="Staff ID of the employee who made the request",
@@ -39,8 +39,14 @@ class ArrangementLog(Base):
     )
     reason_description = Column(
         String(length=255),
-        nullable=True,
+        nullable=False,
         doc="Reason for the status update",
+    )
+    batch_id = Column(
+        Integer,
+        ForeignKey("arrangement_batches.batch_id"),
+        nullable=True,
+        doc="Unique identifier for the batch",
     )
     __table_args__ = (
         CheckConstraint("wfh_type IN ('full', 'am', 'pm')", name="check_wfh_type"),
@@ -48,4 +54,64 @@ class ArrangementLog(Base):
             "approval_status IN ('pending', 'approved', 'rejected', 'withdrawn')",
             name="check_approval_status",
         ),
+    )
+
+
+class ArrangementBatch(Base):
+    __tablename__ = "arrangement_batches"
+    batch_id = Column(
+        Integer,
+        primary_key=True,
+        autoincrement=True,
+        doc="Unique identifier for the batch",
+    )
+    update_datetime = Column(
+        String(length=50),
+        nullable=False,
+        doc="Date and time of the log entry",
+    )
+    requester_staff_id = Column(
+        String(length=10),
+        ForeignKey("employees.staff_id"),
+        nullable=False,
+        doc="Staff ID of the employee who made the request",
+    )
+    wfh_type = Column(
+        String(length=50),
+        nullable=False,
+        doc="Type of WFH arrangement: full day, AM, or PM",
+    )
+    reason_description = Column(
+        String(length=255),
+        nullable=False,
+        doc="Reason for the status update",
+    )
+    start_date = Column(
+        String(length=50),
+        nullable=False,
+        doc="Start date of the batch",
+    )
+    end_date = Column(
+        String(length=50),
+        nullable=False,
+        doc="Type of the batch: full day, AM, or PM",
+    )
+    recurring_frequency_number = Column(
+        Integer,
+        nullable=False,
+        doc="Numerical frequency of the recurring WFH request",
+    )
+    recurring_frequency_unit = Column(
+        String(length=50),
+        nullable=False,
+        doc="Unit of the frequency of the recurring WFH request",
+    )
+    recurring_occurrences = Column(
+        Integer,
+        nullable=False,
+        doc="Number of occurrences of the recurring WFH request",
+    )
+
+    __table_args__ = (
+        CheckConstraint("wfh_type IN ('full', 'am', 'pm')", name="check_batch_type"),
     )

--- a/backend/src/arrangements/schemas.py
+++ b/backend/src/arrangements/schemas.py
@@ -8,17 +8,41 @@ from ..base import BaseSchema
 
 
 class ArrangementBase(BaseSchema):
-    requester_staff_id: int
-    wfh_date: str
-    wfh_type: Literal["full", "am", "pm"]
+    requester_staff_id: int = Field(
+        ..., title="Staff ID of the employee who made the request"
+    )
+    wfh_date: str = Field(
+        ...,
+        title="Date of an adhoc WFH request or the start date of a recurring WFH request",
+    )
+    wfh_type: Literal["full", "am", "pm"] = Field(..., title="Type of WFH arrangement")
 
 
 class ArrangementCreate(ArrangementBase):
     update_datetime: SkipJsonSchema[datetime] = Field(
-        default_factory=datetime.now, exclude=True
+        default_factory=datetime.now,
+        exclude=True,
+        title="Datetime that the request was created",
     )
-    approval_status: SkipJsonSchema[str] = Field(default="pending", exclude=True)
-    reason_description: str
+    approval_status: SkipJsonSchema[str] = Field(
+        default="pending", exclude=True, title="Approval status of the request"
+    )
+    reason_description: str = Field(..., title="Reason for requesting the WFH")
+    is_recurring: bool = Field(
+        default=False, title="Flag to indicate if the request is recurring"
+    )
+    recurring_end_date: str = Field(
+        default=None, title="End date of a recurring WFH request"
+    )
+    recurring_frequency_number: int = Field(
+        default=None, title="Numerical frequency of the recurring WFH request"
+    )
+    recurring_frequency_unit: Literal["week", "month"] = Field(
+        default=None, title="Unit of the frequency of the recurring WFH request"
+    )
+    recurring_occurrences: int = Field(
+        default=None, title="Number of occurrences of the recurring WFH request"
+    )
 
     def model_dump(self, **kwargs):
         data = super().model_dump(**kwargs)


### PR DESCRIPTION
Recurring arrangements will be bulk inserted to the db, which means that if any one fails nothing will be inserted. This ensures that the operation is atomic and retains data integrity.

Besides being inserted as individual arrangements into the arrangement_logs table, each arrangement in a recurring schedule will also be assigned a batch_id and the details of the recurring schedule are stored in the arrangement_batches table.